### PR TITLE
Fix MCP connections imports

### DIFF
--- a/agents/utils/connections.py
+++ b/agents/utils/connections.py
@@ -1,5 +1,7 @@
 """Connection handling for MCP servers."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack
 from typing import Any, TYPE_CHECKING


### PR DESCRIPTION
## Summary
- ensure MCP connections module uses postponed annotation evaluation and required imports

## Testing
- `pytest agents/tests -q` *(fails: missing implementations for DebateSystem, CurriculumSystem, etc.)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932c3ca8468832490e1fde076f94ffe)