### PR TITLE
Add architecture selection policy and sandboxed bash tooling

### DIFF
--- a/agents/core/architecture_selector.py
+++ b/agents/core/architecture_selector.py
@@ -1,0 +1,111 @@
+"""Architecture selection policy with decision matrix defaults.
+
+This module codifies when to prefer 4×, 8×, 16×, or 32× variants based on
+latency tolerance, accuracy priority, risk level, and cost sensitivity.
+The thresholds mirror the guidance in the scalability analysis where 8× is
+the default for balanced cost/benefit, 4× is for latency-constrained
+workloads, and 16×/32× are reserved for high-accuracy or high-risk contexts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from .decision_model import RiskLevel
+
+
+class ArchitectureVariant(Enum):
+    """Supported architecture sizes."""
+
+    FOUR_X = 4
+    EIGHT_X = 8
+    SIXTEEN_X = 16
+    THIRTY_TWO_X = 32
+
+
+@dataclass
+class ArchitectureDecisionInput:
+    """Inputs used to decide which architecture variant to run."""
+
+    latency_tolerance_ms: int
+    accuracy_priority: float  # 0.0 (latency-first) to 1.0 (accuracy-first)
+    risk_level: RiskLevel
+    cost_sensitivity: float  # 0.0 (cost-insensitive) to 1.0 (cost-constrained)
+    availability_constraints: Optional[bool] = False
+
+
+@dataclass
+class ArchitectureRecommendation:
+    """Decision output describing the chosen variant and rationale."""
+
+    variant: ArchitectureVariant
+    reason: str
+    estimated_latency_ms: int
+    logic_weight: float
+    accuracy_gain: float
+
+
+class ArchitectureSelector:
+    """Applies the policy defaults from the scalability analysis."""
+
+    def __init__(self, default_variant: ArchitectureVariant = ArchitectureVariant.EIGHT_X):
+        self.default_variant = default_variant
+
+    def recommend(self, decision: ArchitectureDecisionInput) -> ArchitectureRecommendation:
+        """Return the architecture variant that best matches the policy inputs."""
+
+        # Latency and cost sensitive flows downshift to 4× unless risk/accuracy demand more
+        if decision.latency_tolerance_ms <= 300 or decision.cost_sensitivity >= 0.75:
+            return ArchitectureRecommendation(
+                variant=ArchitectureVariant.FOUR_X,
+                reason="Latency/cost sensitive workload benefits from 4× baseline.",
+                estimated_latency_ms=250,
+                logic_weight=0.60,
+                accuracy_gain=1.0,
+            )
+
+        # Ultra-accuracy cases with relaxed latency and low cost sensitivity reach 32×
+        if (
+            decision.accuracy_priority >= 0.9
+            and decision.latency_tolerance_ms >= 1500
+            and decision.cost_sensitivity <= 0.4
+            and not decision.availability_constraints
+        ):
+            return ArchitectureRecommendation(
+                variant=ArchitectureVariant.THIRTY_TWO_X,
+                reason="Extreme accuracy with relaxed latency/cost enables 32× variant.",
+                estimated_latency_ms=1600,
+                logic_weight=0.88,
+                accuracy_gain=1.22,
+            )
+
+        # Accuracy-first or high-risk scenarios escalate to 16× if latency budget allows
+        if decision.accuracy_priority >= 0.8 or decision.risk_level in {RiskLevel.HIGH, RiskLevel.CRITICAL}:
+            if decision.latency_tolerance_ms >= 850:
+                return ArchitectureRecommendation(
+                    variant=ArchitectureVariant.SIXTEEN_X,
+                    reason="High accuracy/risk with adequate latency budget favors 16× stack.",
+                    estimated_latency_ms=850,
+                    logic_weight=0.82,
+                    accuracy_gain=1.18,
+                )
+            # If timing is tighter, prefer 8× but annotate why 16× was avoided
+            return ArchitectureRecommendation(
+                variant=ArchitectureVariant.EIGHT_X,
+                reason="High accuracy/risk detected but latency budget keeps us at 8×.",
+                estimated_latency_ms=450,
+                logic_weight=0.75,
+                accuracy_gain=1.12,
+            )
+
+        # Balanced default
+        return ArchitectureRecommendation(
+            variant=self.default_variant,
+            reason="Balanced workload defaults to 8× per scalability guidance.",
+            estimated_latency_ms=450,
+            logic_weight=0.75,
+            accuracy_gain=1.12,
+        )
+

--- a/agents/tests/test_architecture_selector.py
+++ b/agents/tests/test_architecture_selector.py
@@ -1,0 +1,67 @@
+from agents.core.architecture_selector import (
+    ArchitectureDecisionInput,
+    ArchitectureSelector,
+    ArchitectureVariant,
+)
+from agents.core.decision_model import RiskLevel
+
+
+def test_latency_sensitive_prefers_4x():
+    selector = ArchitectureSelector()
+    decision = ArchitectureDecisionInput(
+        latency_tolerance_ms=250,
+        accuracy_priority=0.3,
+        risk_level=RiskLevel.LOW,
+        cost_sensitivity=0.9,
+    )
+
+    rec = selector.recommend(decision)
+
+    assert rec.variant is ArchitectureVariant.FOUR_X
+    assert "Latency" in rec.reason
+
+
+def test_high_accuracy_and_risk_reaches_16x_when_budget_allows():
+    selector = ArchitectureSelector()
+    decision = ArchitectureDecisionInput(
+        latency_tolerance_ms=1000,
+        accuracy_priority=0.9,
+        risk_level=RiskLevel.HIGH,
+        cost_sensitivity=0.2,
+    )
+
+    rec = selector.recommend(decision)
+
+    assert rec.variant is ArchitectureVariant.SIXTEEN_X
+    assert rec.logic_weight > 0.8
+
+
+def test_default_balances_to_8x():
+    selector = ArchitectureSelector()
+    decision = ArchitectureDecisionInput(
+        latency_tolerance_ms=600,
+        accuracy_priority=0.6,
+        risk_level=RiskLevel.MEDIUM,
+        cost_sensitivity=0.4,
+    )
+
+    rec = selector.recommend(decision)
+
+    assert rec.variant is ArchitectureVariant.EIGHT_X
+    assert "Balanced" in rec.reason
+
+
+def test_extreme_accuracy_with_low_cost_sensitivity_enables_32x():
+    selector = ArchitectureSelector()
+    decision = ArchitectureDecisionInput(
+        latency_tolerance_ms=2000,
+        accuracy_priority=0.95,
+        risk_level=RiskLevel.MEDIUM,
+        cost_sensitivity=0.2,
+    )
+
+    rec = selector.recommend(decision)
+
+    assert rec.variant is ArchitectureVariant.THIRTY_TWO_X
+    assert rec.logic_weight > 0.85
+

--- a/agents/tests/test_command_security.py
+++ b/agents/tests/test_command_security.py
@@ -1,0 +1,40 @@
+import os
+
+from agents.tools.security import CommandSecurityPolicy, ValidationResult
+
+
+def test_allowlisted_command_passes_validation():
+    policy = CommandSecurityPolicy()
+
+    result = policy.validate("ls -la")
+
+    assert isinstance(result, ValidationResult)
+    assert result.allowed
+
+
+def test_block_non_allowlisted_command():
+    policy = CommandSecurityPolicy()
+
+    result = policy.validate("rm -rf /")
+
+    assert not result.allowed
+    assert "not allowed" in result.reason
+
+
+def test_block_pkill_for_disallowed_process():
+    policy = CommandSecurityPolicy()
+
+    result = policy.validate("pkill -f python")
+
+    assert not result.allowed
+    assert "allowlist" in result.reason
+
+
+def test_block_working_directory_outside_sandbox():
+    policy = CommandSecurityPolicy()
+
+    result = policy.validate("ls", working_directory="/tmp")
+
+    assert not result.allowed
+    assert "outside the sandbox" in result.reason
+

--- a/agents/tools/__init__.py
+++ b/agents/tools/__init__.py
@@ -6,6 +6,8 @@ from .code_execution import CodeExecutionServerTool
 from .file_tools import FileReadTool, FileWriteTool
 from .think import ThinkTool
 from .web_search import WebSearchServerTool
+from .scenario_library import ScenarioBundle, get_scenario_bundle
+from .security import CommandSecurityPolicy
 
 __all__ = [
     "Tool",
@@ -15,4 +17,7 @@ __all__ = [
     "FileWriteTool",
     "ThinkTool",
     "WebSearchServerTool",
+    "ScenarioBundle",
+    "get_scenario_bundle",
+    "CommandSecurityPolicy",
 ]

--- a/agents/tools/scenario_library.py
+++ b/agents/tools/scenario_library.py
@@ -1,0 +1,68 @@
+"""Domain-specific scenario bundles and prompts.
+
+Each bundle pairs a tailored system prompt with recommended tools and a
+multi-agent handoff sequence inspired by the autonomous-coding harness.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class ScenarioBundle:
+    """A reusable bundle for initializing an agent in a domain."""
+
+    name: str
+    description: str
+    system_prompt: str
+    tool_names: List[str]
+    handoff_sequence: List[str] = field(default_factory=list)
+    safety_posture: str = "logic-weighted with audit trail"
+
+
+SCENARIO_LIBRARY: Dict[str, ScenarioBundle] = {
+    "governance": ScenarioBundle(
+        name="Governance",
+        description="Policy-aware reasoning with procedural safeguards and auditability.",
+        system_prompt=(
+            "You are a governance advisor. Weight formal logic and precedent heavily, "
+            "surface conflicts, and recommend procedural next steps with citations."
+        ),
+        tool_names=["web_search", "think", "calculator"],
+        handoff_sequence=["policy-analysis", "risk-triage", "decision-draft"],
+    ),
+    "compliance": ScenarioBundle(
+        name="Compliance",
+        description="Control testing, obligation mapping, and evidence tracking.",
+        system_prompt=(
+            "You are a compliance analyst. Map requirements to controls, flag gaps, "
+            "and propose remediation with traceable evidence and risk bands."
+        ),
+        tool_names=["file_tools", "web_search", "think"],
+        handoff_sequence=["obligation-intake", "evidence-scan", "remediation-plan"],
+        safety_posture="strict allowlist for file access and bash execution",
+    ),
+    "scientific_review": ScenarioBundle(
+        name="Scientific Review",
+        description="Peer-review style appraisal with replication checks and uncertainty quantification.",
+        system_prompt=(
+            "You are a scientific reviewer. Evaluate methodology, quantify uncertainty, "
+            "and suggest replication strategies using conservative inference."
+        ),
+        tool_names=["calculator", "web_search", "think"],
+        handoff_sequence=["claim-mapping", "evidence-weighing", "replication-plan"],
+        safety_posture="logic-majority voting with counterfactual probes",
+    ),
+}
+
+
+def get_scenario_bundle(name: str) -> ScenarioBundle:
+    """Return a scenario bundle by key, raising for unknown entries."""
+
+    key = name.lower()
+    if key not in SCENARIO_LIBRARY:
+        raise KeyError(f"Scenario '{name}' is not defined in the library")
+    return SCENARIO_LIBRARY[key]
+

--- a/agents/tools/security.py
+++ b/agents/tools/security.py
@@ -1,0 +1,215 @@
+"""Shared security utilities mirroring the autonomous-coding sandbox."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+from dataclasses import dataclass, field
+from typing import Iterable, List, Set
+
+
+DEFAULT_ALLOWED_COMMANDS: Set[str] = {
+    # File inspection
+    "ls",
+    "cat",
+    "head",
+    "tail",
+    "wc",
+    "grep",
+    # File operations
+    "cp",
+    "mkdir",
+    "chmod",
+    # Directory
+    "pwd",
+    # Node.js development
+    "npm",
+    "node",
+    # Version control
+    "git",
+    # Process management
+    "ps",
+    "lsof",
+    "sleep",
+    "pkill",
+    # Script execution
+    "init.sh",
+}
+
+COMMANDS_NEEDING_EXTRA_VALIDATION = {"pkill", "chmod", "init.sh"}
+
+
+@dataclass
+class ValidationResult:
+    allowed: bool
+    reason: str = ""
+
+
+def split_command_segments(command_string: str) -> list[str]:
+    """Split compound commands on &&, ||, and ; while respecting quotes."""
+
+    segments = re.split(r"\s*(?:&&|\|\|)\s*", command_string)
+    result: list[str] = []
+    for segment in segments:
+        sub_segments = re.split(r"(?<![\"'])\s*;\s*(?![\"'])", segment)
+        for sub in sub_segments:
+            sub = sub.strip()
+            if sub:
+                result.append(sub)
+    return result
+
+
+def extract_commands(command_string: str) -> list[str]:
+    """Extract command names from a shell string, handling pipes and chaining."""
+
+    commands: list[str] = []
+    segments = re.split(r"(?<![\"'])\s*;\s*(?![\"'])", command_string)
+
+    for segment in segments:
+        segment = segment.strip()
+        if not segment:
+            continue
+
+        try:
+            tokens = shlex.split(segment)
+        except ValueError:
+            return []
+
+        if not tokens:
+            continue
+
+        expect_command = True
+        for token in tokens:
+            if token in ("|", "||", "&&", "&"):
+                expect_command = True
+                continue
+            if token in (
+                "if",
+                "then",
+                "else",
+                "elif",
+                "fi",
+                "for",
+                "while",
+                "until",
+                "do",
+                "done",
+                "case",
+                "esac",
+                "in",
+                "!",
+                "{",
+                "}",
+            ):
+                continue
+            if token.startswith("-"):
+                continue
+            if "=" in token and not token.startswith("="):
+                continue
+            if expect_command:
+                commands.append(os.path.basename(token))
+                expect_command = False
+
+    return commands
+
+
+def validate_pkill_command(command_string: str) -> ValidationResult:
+    """Only allow pkill for common dev processes."""
+
+    allowed_process_names = {"node", "npm", "npx", "vite", "next"}
+
+    try:
+        tokens = shlex.split(command_string)
+    except ValueError:
+        return ValidationResult(False, "Could not parse pkill command")
+
+    if len(tokens) < 2:
+        return ValidationResult(False, "pkill requires a process name")
+
+    args = [token for token in tokens[1:] if not token.startswith("-")]
+    if not args:
+        return ValidationResult(False, "pkill requires a process name")
+
+    target = args[-1]
+    process = target.split()[0]
+
+    if process not in allowed_process_names:
+        return ValidationResult(False, f"pkill target '{process}' is not in allowlist")
+
+    return ValidationResult(True)
+
+
+def validate_chmod_command(command_string: str) -> ValidationResult:
+    """Allow chmod only for making scripts executable inside allowed roots."""
+
+    try:
+        tokens = shlex.split(command_string)
+    except ValueError:
+        return ValidationResult(False, "Could not parse chmod command")
+
+    if len(tokens) < 3:
+        return ValidationResult(False, "chmod requires mode and target")
+
+    mode = tokens[1]
+    if mode not in {"+x", "755", "0755"}:
+        return ValidationResult(False, "chmod may only set executable bits")
+
+    return ValidationResult(True)
+
+
+def validate_init_script(command_string: str) -> ValidationResult:
+    """Block running arbitrary init scripts; require explicit allowlisting."""
+
+    return ValidationResult(False, "init scripts must be reviewed before execution")
+
+
+def validate_commands(segment: str, commands: Iterable[str]) -> ValidationResult:
+    for command in commands:
+        if command == "pkill":
+            return validate_pkill_command(segment)
+        if command == "chmod":
+            return validate_chmod_command(segment)
+        if command == "init.sh":
+            return validate_init_script(segment)
+    return ValidationResult(True)
+
+
+@dataclass
+class CommandSecurityPolicy:
+    """Allowlist-based sandbox policy for bash execution."""
+
+    allowed_commands: Set[str] = field(default_factory=lambda: set(DEFAULT_ALLOWED_COMMANDS))
+    allowed_paths: List[str] = field(default_factory=lambda: [os.path.abspath(os.getcwd())])
+
+    def is_path_allowed(self, directory: str | None) -> bool:
+        if directory is None:
+            return True
+
+        abs_dir = os.path.abspath(directory)
+        return any(abs_dir.startswith(os.path.abspath(path)) for path in self.allowed_paths)
+
+    def validate(self, command: str, working_directory: str | None = None) -> ValidationResult:
+        if not command.strip():
+            return ValidationResult(False, "Command is empty")
+
+        segments = split_command_segments(command)
+        for segment in segments:
+            commands = extract_commands(segment)
+            if not commands:
+                return ValidationResult(False, "Unable to parse command")
+
+            for cmd in commands:
+                if cmd not in self.allowed_commands:
+                    return ValidationResult(False, f"Command '{cmd}' is not allowed")
+
+            if any(cmd in COMMANDS_NEEDING_EXTRA_VALIDATION for cmd in commands):
+                validation = validate_commands(segment, commands)
+                if not validation.allowed:
+                    return validation
+
+        if not self.is_path_allowed(working_directory):
+            return ValidationResult(False, "Working directory is outside the sandbox")
+
+        return ValidationResult(True)
+

--- a/agents/utils/connections.py
+++ b/agents/utils/connections.py
@@ -1,5 +1,7 @@
 """Connection handling for MCP servers."""
 
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
 from contextlib import AsyncExitStack
 from typing import Any, TYPE_CHECKING


### PR DESCRIPTION
## Summary
- add an architecture selection helper that codifies latency/accuracy/risk tradeoffs
- introduce allowlist-based bash security utilities and apply them to the Bash tool
- add scenario bundles for governance, compliance, and scientific review plus regression tests for selection and security

## Testing
- python -m pytest -o addopts='' agents/tests/test_architecture_selector.py agents/tests/test_command_security.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932cb61af7083248360e6e226c1d6ee)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added architecture selection enabling optimization across performance variants with configurable latency and cost trade-offs
  * Introduced command execution security validation restricting shell operations to safe, allowlisted commands and paths
  * Provided predefined scenario bundles for governance, compliance, and scientific review deployments

* **Tests**
  * New test coverage for architecture selection, command security validation, and scenario lookup

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->