### PR TITLE
Add lazy imports to agents package

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,6 +1,21 @@
 """Core agent implementations."""
 
-from .agent import Agent, ModelConfig
-from .tools.base import Tool
+# Lazy imports keep optional dependencies (like the anthropic SDK) from being
+# required at package import time. This allows subpackages such as
+# ``agents.governance`` to be imported in environments where the SDK is not
+# installed, while still providing the same public API when users access
+# ``Agent`` or related classes directly.
 
 __all__ = ["Agent", "ModelConfig", "Tool"]
+
+
+def __getattr__(name):
+    if name in {"Agent", "ModelConfig"}:
+        from .agent import Agent, ModelConfig
+
+        return {"Agent": Agent, "ModelConfig": ModelConfig}[name]
+    if name == "Tool":
+        from .tools.base import Tool
+
+        return Tool
+    raise AttributeError(f"module 'agents' has no attribute '{name}'")


### PR DESCRIPTION
## Summary
- switch the agents package to use lazy attribute loading
- prevent optional anthropic dependency from being required during package import

## Testing
- pytest agents/tests -v --junitxml=junit/agents-test-results.xml

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935877e147083249ca3fbf0ae187167)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized module initialization for improved startup performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->