### PR TITLE
Prevent pytest collection of manual message params suite

### DIFF
--- a/agents/test_message_params.py
+++ b/agents/test_message_params.py
@@ -15,6 +15,7 @@ from agents.agent import Agent, ModelConfig
 
 
 class TestMessageParams:
+    __test__ = False  # Prevent pytest collection (requires live API key)
     """Test cases for message_params functionality."""
 
     def __init__(self, verbose: bool = True):


### PR DESCRIPTION
## Summary
- mark the manual message_params test suite as non-pytest to avoid collection warnings that require a live API key

## Testing
- python -m pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69348f553a94832497748de60423693a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * Updated internal test configuration.

---

**Note:** This release contains no user-facing changes or new features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->