### PR TITLE
Replace hashFiles gating in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,8 +13,25 @@ on:
       - .github/**
       - computer-use-demo/**
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      computer_use_demo: ${{ steps.filter.outputs.computer_use_demo }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for computer-use-demo changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            computer_use_demo:
+              - 'computer-use-demo/**'
+
   build-amd64:
-    if: ${{ always() && hashFiles('computer-use-demo/**') != '' }}
+    needs: changes
+    if: ${{ needs.changes.outputs.computer_use_demo == 'true' }}
     uses: ./.github/workflows/reusable_build_step.yaml
     with:
       platform: amd64
@@ -26,7 +43,8 @@ jobs:
       contents: read
       packages: write
   build-arm64:
-    if: ${{ always() && hashFiles('computer-use-demo/**') != '' }}
+    needs: changes
+    if: ${{ needs.changes.outputs.computer_use_demo == 'true' }}
     uses: ./.github/workflows/reusable_build_step.yaml
     with:
       platform: arm64
@@ -38,9 +56,10 @@ jobs:
       contents: read
       packages: write
   merge:
-    if: ${{ always() && hashFiles('computer-use-demo/**') != '' }}
+    if: ${{ needs.changes.outputs.computer_use_demo == 'true' }}
     runs-on: ubuntu-latest
     needs:
+      - changes
       - build-arm64
       - build-amd64
     permissions:


### PR DESCRIPTION
## Summary
- add a preliminary changes job using dorny/paths-filter to detect computer-use-demo updates
- gate build and merge jobs on the detected changes instead of unsupported hashFiles expressions

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935c7006cb483248133f3182ef9be84)