### PR TITLE
Fix duplicate getattr definitions in agents module

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -39,14 +39,7 @@ def __getattr__(name: str):
         globals().update({"Agent": Agent, "ModelConfig": ModelConfig})
         return globals()[name]
 
-    raise AttributeError(name)
-def __getattr__(name):
-    if name in {"Agent", "ModelConfig"}:
-        from .agent import Agent, ModelConfig
-
-        return {"Agent": Agent, "ModelConfig": ModelConfig}[name]
     if name == "Tool":
-        from .tools.base import Tool
-
         return Tool
+
     raise AttributeError(f"module 'agents' has no attribute '{name}'")


### PR DESCRIPTION
## Summary
- consolidate agents.__getattr__ into a single implementation to avoid duplicate definitions
- preserve lazy import behavior for Agent and ModelConfig and handle Tool access

## Testing
- ruff check agents/__init__.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935c86883f083248499390da73371f6)