### PR TITLE
Add truth table path regression test

### DIFF
--- a/agents/core_logic/logic_engine.py
+++ b/agents/core_logic/logic_engine.py
@@ -205,19 +205,20 @@ class LogicEngine:
                 warnings=warnings,
             )
 
-            # Method 2: Truth table evaluation (slow but complete) or heuristic fallback
-            if len(argument.propositions) > 5:
-                warnings.append(
-                    f"Too many variables ({len(argument.propositions)}) for truth table evaluation"
-                )
-                warnings.append("Using heuristic evaluation - not deterministic")
-                return self._heuristic_validate(argument, warnings)
-            else:
-                truth_result = self._truth_table_validate(argument)
-                if truth_result:
-                    return truth_result
-                warnings.append("Using heuristic evaluation - not deterministic")
-                return self._heuristic_validate(argument, warnings)
+        # Method 2: Truth table evaluation (slow but complete) or heuristic fallback
+        if len(argument.propositions) > 5:
+            warnings.append(
+                f"Too many variables ({len(argument.propositions)}) for truth table evaluation"
+            )
+            warnings.append("Using heuristic evaluation - not deterministic")
+            return self._heuristic_validate(argument, warnings)
+
+        truth_result = self._truth_table_validate(argument)
+        if truth_result:
+            return truth_result
+
+        warnings.append("Using heuristic evaluation - not deterministic")
+        return self._heuristic_validate(argument, warnings)
 
     def _pattern_match(self, argument: LogicalArgument) -> Optional[ValidationResult]:
         """

--- a/tests/logic/test_logic_engine.py
+++ b/tests/logic/test_logic_engine.py
@@ -133,6 +133,18 @@ class TestTruthTable:
             # Counterexample should have P=False (makes premise true, conclusion false)
             assert result.counterexample.get("P") is False
 
+    def test_truth_table_used_when_no_pattern_matches(self):
+        """Ensure truth table evaluation runs after pattern analysis when needed."""
+        # This form does not match a predefined pattern but is valid
+        arg = parse_argument(["P ∧ Q", "R"], "P")
+        engine = LogicEngine()
+
+        result = engine.validate(arg)
+
+        assert result.method == "truth_table"
+        assert result.is_valid is True
+        assert result.truth_table_valid is True
+
 
 class TestEdgeCases:
     """Test edge cases and error handling."""


### PR DESCRIPTION
## Summary
- add regression test to ensure the logic engine falls back to truth table evaluation when no pattern matches
- verify truth table results stay deterministic for valid arguments without predefined patterns

## Testing
- python -m pytest tests/logic/test_logic_engine.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935ce864b80832482c2b8ff4f5413ca)