### PR TITLE
Potential fix for code scanning alert no. 3: Bad HTML filtering regexp

### DIFF
--- a/agents/core/robustness_system.py
+++ b/agents/core/robustness_system.py
@@ -89,7 +89,8 @@ class InputValidator:
         """Add default security patterns."""
         # Potential injection patterns
         self.forbidden_patterns.extend([
-            re.compile(r"<script.*?>.*?</script>", re.IGNORECASE | re.DOTALL),
+            # Improved pattern: matches <script> blocks with flexible closing tags and attributes
+            re.compile(r"<script\b[^>]*>.*?</script\b[^>]*>", re.IGNORECASE | re.DOTALL),
             re.compile(r"javascript:", re.IGNORECASE),
             re.compile(r"on\w+\s*=", re.IGNORECASE),  # Event handlers
             re.compile(r"\{\{.*?\}\}"),  # Template injection


### PR DESCRIPTION
Potential fix for [https://github.com/slittyjuice-source/reasonable-mind/security/code-scanning/3](https://github.com/slittyjuice-source/reasonable-mind/security/code-scanning/3)

To fix this issue, we should avoid implementing risky HTML filtering via regular expressions and instead employ a well-tested HTML sanitization library that can robustly strip scripts and other dangerous content. However, if external libraries cannot be used and changes must remain strictly within the current code, the best fix is to tighten the regex so it matches more variants of script tags, including those with extra spaces or attributes inside the end tag, as much as possible.

Specifically, we should replace `re.compile(r"<script.*?>.*?</script>", ...)` with a pattern that accounts for any whitespace and attributes in both start and end tags. A pattern like `<script\b[^>]*>.*?</script\b[^>]*>` (with `re.DOTALL | re.IGNORECASE`) is better, as it matches `<script ...>...</script ...>`, and allows optional whitespace or attributes in the closing tag before `>`.

If possible, also recommend (with inline comments) to consider using a well-tested HTML sanitizer in the future, as regular expressions on their own are never 100% safe for HTML.

All edits are solely within agents/core/robustness_system.py, line 92.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
